### PR TITLE
Update README to include global electron installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Modern MP3 Player
 $ git clone https://github.com/sanket143/MJam.git
 $ cd MJam
 $ npm install
+$ npm install -g electron
 $ npm start
 ```
 

--- a/scripts/components/nowplaying.js
+++ b/scripts/components/nowplaying.js
@@ -20,9 +20,11 @@ const nowplaying_frame = new Vue({
       return state.nowplaying.song
     },
     onRepeatChange(){
-      state.nowplaying.instance.loop(state.settings.repeat)
-      saveSettings()
-      return state.settings.repeat
+      if(state.nowplaying.instance) {
+        state.nowplaying.instance.loop(state.settings.repeat)
+        saveSettings()
+        return state.settings.repeat
+      }
     }
   },
   methods: {


### PR DESCRIPTION
## What
When running the application locally for development, I noticed the README.md file was missing the step for installing electron globally. 

## Why
For beginners who don't know the difference between global npm packages and those local to a project, this explicitly gives the step for installing electron, which is required by the npm start script used in this project. Without the global electron installation, ```npm start``` does not work.