### PR TITLE
Resolve Issue #42

### DIFF
--- a/scripts/components/nowplaying.js
+++ b/scripts/components/nowplaying.js
@@ -20,9 +20,11 @@ const nowplaying_frame = new Vue({
       return state.nowplaying.song
     },
     onRepeatChange(){
-      state.nowplaying.instance.loop(state.settings.repeat)
-      saveSettings()
-      return state.settings.repeat
+      if(state.nowplaying.instance) {
+        state.nowplaying.instance.loop(state.settings.repeat)
+        saveSettings()
+        return state.settings.repeat
+      }
     }
   },
   methods: {


### PR DESCRIPTION
## What
#42 

## Solution
Add check for state.nowplaying.instance before calling loop function.

Looking at how the .user/recent.data.json is loaded at startup, there is currently no checks for if a nowplaying Howl object has been instantiated. onRepeatChange() is called at startup and thus we need to check if state.nowplaying.instance exists before trying to execute the loop() function provided by a Howl object.