### PR TITLE
Resolve Issue #41

### DIFF
--- a/scripts/components/nowplaying.js
+++ b/scripts/components/nowplaying.js
@@ -20,9 +20,11 @@ const nowplaying_frame = new Vue({
       return state.nowplaying.song
     },
     onRepeatChange(){
-      state.nowplaying.instance.loop(state.settings.repeat)
-      saveSettings()
-      return state.settings.repeat
+      if(state.nowplaying.instance) {
+        state.nowplaying.instance.loop(state.settings.repeat)
+        saveSettings()
+        return state.settings.repeat
+      }
     }
   },
   methods: {

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -24,12 +24,17 @@ var { readJSON, saveCache, extractAndStoreMetaTags } = require("./scripts/method
     })
     .catch((err) => {
       console.log(err)
+      let firstSongSet = false
 
       let finder = findit(state.settings.lookupLocation)
 
       finder.on('file', (file) => {
         if (path.extname(file) == ".mp3") {
           state.allFiles.push(file)
+          if(!firstSongSet) {
+            state.load([state.allFiles[0]])
+            firstSongSet = true
+          }
         }
       })
 


### PR DESCRIPTION
## What
#41 

## Solution
The issue of playing the first song was only seen when the first song in the list matched the initial song loaded by nowplaying. This is caused when no nowplaying.instance exists. This occurs when the app starts up and tries to read a non-existent recent songs json file. To resolve this, we can simply set the initial song loaded by the app to the first song in the users library. If the user has a recent songs list, this will be overwritten.