### PR TITLE
Update readme to include global install of electron (needed for npm s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Modern MP3 Player
 $ git clone https://github.com/sanket143/MJam.git
 $ cd MJam
 $ npm install
+$ npm install -g electron
 $ npm start
 ```
 


### PR DESCRIPTION
## What
When running the application locally for development, I noticed the README.md file was missing the step for installing electron globally.

## Why
For beginners who don't know the difference between global npm packages and those local to a project, this explicitly gives the step for installing electron, which is required by the npm start script used in this project. Without the global electron installation, npm start does not work.